### PR TITLE
[FEAT] Multi-rover mission

### DIFF
--- a/docs/user-stories/README.md
+++ b/docs/user-stories/README.md
@@ -14,11 +14,11 @@ If this were a 50-story backlog, the Core tier would contain ~10 stories (20%). 
 
 | ID | File | Title | Layer | Priority | Status |
 |----|------|-------|-------|----------|--------|
-| PLATEAU-STORY-001 | [plateau.md](plateau.md) | Define the plateau | Domain | 🔴 Core | ⬜ Todo |
-| ROVER-STORY-001 | [deploy-rover.md](deploy-rover.md) | Deploy a rover | Domain | 🔴 Core | ⬜ Todo |
-| NAV-STORY-001 | [navigate-rover.md](navigate-rover.md) | Navigate a rover | Domain | 🔴 Core | ⬜ Todo |
-| CLI-STORY-002 | [report-positions.md](report-positions.md) | Report final positions | Adapter | 🔴 Core | ⬜ Todo |
-| NAV-STORY-002 | [boundary-safe-stop.md](boundary-safe-stop.md) | Boundary safe-stop | Domain | 🔴 Core | ⬜ Todo |
+| PLATEAU-STORY-001 | [plateau.md](plateau.md) | Define the plateau | Domain | 🔴 Core | ✅ Implemented |
+| ROVER-STORY-001 | [deploy-rover.md](deploy-rover.md) | Deploy a rover | Domain | 🔴 Core | ✅ Implemented |
+| NAV-STORY-001 | [navigate-rover.md](navigate-rover.md) | Navigate a rover | Domain | 🔴 Core | ✅ Implemented |
+| CLI-STORY-002 | [report-positions.md](report-positions.md) | Report final positions | Adapter | 🔴 Core | ✅ Implemented |
+| NAV-STORY-002 | [boundary-safe-stop.md](boundary-safe-stop.md) | Boundary safe-stop | Domain | 🔴 Core | ✅ Implemented |
 | MISSION-STORY-001 | [multi-rover-mission.md](multi-rover-mission.md) | Multi-rover mission | Application | 🟡 Secondary | ⬜ Todo |
 | CLI-STORY-001 | [cli-input.md](cli-input.md) | CLI pipe input | Adapter | 🟡 Secondary | ⬜ Todo |
 | CLI-STORY-003 | [input-validation.md](input-validation.md) | Input validation & errors | Adapter | 🟡 Secondary | ⬜ Todo |
@@ -80,11 +80,11 @@ All scenarios use **GIVEN-WHEN-THEN** format with unique scenario IDs: `{STORY-I
 
 ## Progress Tracker
 
-- [ ] PLATEAU-STORY-001 Define the plateau
-- [ ] ROVER-STORY-001 Deploy a rover
-- [ ] NAV-STORY-001 Navigate a rover
-- [ ] CLI-STORY-002 Report final positions
-- [ ] NAV-STORY-002 Boundary safe-stop
+ - [x] PLATEAU-STORY-001 Define the plateau
+ - [x] ROVER-STORY-001 Deploy a rover
+ - [x] NAV-STORY-001 Navigate a rover
+ - [x] CLI-STORY-002 Report final positions
+ - [x] NAV-STORY-002 Boundary safe-stop
 - [ ] MISSION-STORY-001 Multi-rover mission
 - [ ] CLI-STORY-001 CLI pipe input
 - [ ] CLI-STORY-003 Input validation & errors

--- a/mars_rover/__main__.py
+++ b/mars_rover/__main__.py
@@ -1,5 +1,25 @@
+import sys
+
+from mars_rover.adapters.input_parser import InputParser
+from mars_rover.adapters.output_formatter import OutputFormatter
+from mars_rover.application.mission_controller import MissionController
+
+
 def main() -> None:
-    print("Mars Rover ready")
+    text = sys.stdin.read()
+    if not text.strip():
+        sys.exit(0)
+    try:
+        parser = InputParser()
+        plateau, missions = parser.parse(text)
+    except ValueError as exc:
+        print(f"Input error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    controller = MissionController(plateau)
+    formatter = OutputFormatter()
+    for rover in controller.run(missions):
+        print(formatter.format(rover))
 
 
 if __name__ == "__main__":

--- a/tests/application/test_mission_controller.py
+++ b/tests/application/test_mission_controller.py
@@ -22,3 +22,21 @@ class TestMissionStory001S1(unittest.TestCase):
         # THEN: Each rover processed its own command independently
         self.assertEqual(results[0].heading, Heading.W)  # rover1 turned left
         self.assertEqual(results[1].heading, Heading.S)  # rover2 turned right
+
+
+class TestMissionStory001S2(unittest.TestCase):
+    def test_s2_given_rover1_finishes_when_rover2_starts_then_rover2_uses_own_position(
+        self,
+    ):
+        # GIVEN: Rover 1 at boundary, Rover 2 at its own start
+        plateau = Plateau(5, 5)
+        rover1 = Rover(5, 5, Heading.N)
+        rover2 = Rover(0, 0, Heading.E)
+        controller = MissionController(plateau)
+
+        # WHEN: Mission runs
+        results = controller.run([(rover1, "M"), (rover2, "M")])
+
+        # THEN: Rover 2 starts from its own position, unaffected by rover 1
+        self.assertEqual(results[1].x, 1)
+        self.assertEqual(results[1].y, 0)

--- a/tests/application/test_mission_controller.py
+++ b/tests/application/test_mission_controller.py
@@ -40,3 +40,22 @@ class TestMissionStory001S2(unittest.TestCase):
         # THEN: Rover 2 starts from its own position, unaffected by rover 1
         self.assertEqual(results[1].x, 1)
         self.assertEqual(results[1].y, 0)
+
+
+class TestMissionStory001S3(unittest.TestCase):
+    def test_s3_given_two_rovers_when_output_produced_then_one_result_per_rover(
+        self,
+    ):
+        # GIVEN: Two rovers complete their missions
+        plateau = Plateau(5, 5)
+        rover1 = Rover(1, 2, Heading.N)
+        rover2 = Rover(3, 3, Heading.E)
+        controller = MissionController(plateau)
+
+        # WHEN: Mission runs
+        results = controller.run([(rover1, ""), (rover2, "")])
+
+        # THEN: Two results in deployment order
+        self.assertEqual(len(results), 2)
+        self.assertIs(results[0], rover1)
+        self.assertIs(results[1], rover2)

--- a/tests/application/test_mission_controller.py
+++ b/tests/application/test_mission_controller.py
@@ -59,3 +59,27 @@ class TestMissionStory001S3(unittest.TestCase):
         self.assertEqual(len(results), 2)
         self.assertIs(results[0], rover1)
         self.assertIs(results[1], rover2)
+
+
+class TestMissionStory001S4(unittest.TestCase):
+    def test_s4_given_kata_input_when_mission_runs_then_correct_final_positions(
+        self,
+    ):
+        # GIVEN: Kata example — plateau 5x5, two rovers with full command strings
+        plateau = Plateau(5, 5)
+        missions = [
+            (Rover(1, 2, Heading.N), "LMLMLMLMM"),
+            (Rover(3, 3, Heading.E), "MMRMMRMRRM"),
+        ]
+        controller = MissionController(plateau)
+
+        # WHEN: Mission runs
+        results = controller.run(missions)
+
+        # THEN: Rover 1 ends at 1 3 N, Rover 2 ends at 5 1 E
+        self.assertEqual(results[0].x, 1)
+        self.assertEqual(results[0].y, 3)
+        self.assertEqual(results[0].heading, Heading.N)
+        self.assertEqual(results[1].x, 5)
+        self.assertEqual(results[1].y, 1)
+        self.assertEqual(results[1].heading, Heading.E)

--- a/tests/application/test_mission_controller.py
+++ b/tests/application/test_mission_controller.py
@@ -1,0 +1,24 @@
+import unittest
+
+from mars_rover.application.mission_controller import MissionController
+from mars_rover.domain.heading import Heading
+from mars_rover.domain.plateau import Plateau
+from mars_rover.domain.rover import Rover
+
+
+class TestMissionStory001S1(unittest.TestCase):
+    def test_s1_given_two_rovers_when_mission_runs_then_each_processes_own_commands(
+        self,
+    ):
+        # GIVEN: Two rovers with separate command strings
+        plateau = Plateau(5, 5)
+        rover1 = Rover(1, 2, Heading.N)
+        rover2 = Rover(3, 3, Heading.E)
+        controller = MissionController(plateau)
+
+        # WHEN: The mission runs
+        results = controller.run([(rover1, "L"), (rover2, "R")])
+
+        # THEN: Each rover processed its own command independently
+        self.assertEqual(results[0].heading, Heading.W)  # rover1 turned left
+        self.assertEqual(results[1].heading, Heading.S)  # rover2 turned right


### PR DESCRIPTION
## 📋 Description
Implements `MissionController` in the application layer to orchestrate sequential execution of multiple rovers, wires it into the CLI entry point, and marks all related user stories as implemented.

## 🔗 Related Issue
Closes #27

## 🧪 How to Test
```bash
echo '5 5
1 2 N
LMLMLMLMM
3 3 E
MMRMMRMRRM' | python -m mars_rover
```
Expected output:
```
1 3 N
5 1 E
```

## ✅ Checklist
- [x] Follows commit message convention
- [x] Pre-commit hooks pass
- [x] Linked to a GitHub issue
- [x] PR title matches branch type prefix