### PR TITLE
[FEAT] CLI pipe input

### DIFF
--- a/mars_rover/__main__.py
+++ b/mars_rover/__main__.py
@@ -1,5 +1,25 @@
+import sys
+
+from mars_rover.adapters.input_parser import InputParser
+from mars_rover.adapters.output_formatter import OutputFormatter
+from mars_rover.application.mission_controller import MissionController
+
+
 def main() -> None:
-    print("Mars Rover ready")
+    text = sys.stdin.read()
+    if not text.strip():
+        return
+    try:
+        parser = InputParser()
+        plateau, missions = parser.parse(text)
+    except ValueError as exc:
+        print(f"Input error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    controller = MissionController(plateau)
+    formatter = OutputFormatter()
+    for rover in controller.run(missions):
+        print(formatter.format(rover))
 
 
 if __name__ == "__main__":

--- a/tests/adapters/test_input_parser.py
+++ b/tests/adapters/test_input_parser.py
@@ -1,0 +1,43 @@
+import unittest
+
+from mars_rover.adapters.input_parser import InputParser
+from mars_rover.domain.heading import Heading
+from mars_rover.domain.plateau import Plateau
+
+KATA_INPUT = "5 5\n1 2 N\nLMLMLMLMM\n3 3 E\nMMRMMRMRRM\n"
+
+
+class TestInputParser(unittest.TestCase):
+    def test_cli_story_001_s1_given_valid_input_when_parse_called_then_returns_plateau(
+        self,
+    ):
+        # GIVEN: Valid input text with plateau + 2 rovers
+        parser = InputParser()
+
+        # WHEN: InputParser.parse() is called
+        plateau, _ = parser.parse(KATA_INPUT)
+
+        # THEN: Returns a Plateau with correct dimensions
+        self.assertEqual(plateau, Plateau(5, 5))
+
+    def test_cli_story_001_s2_given_kata_input_when_parse_called_then_two_missions(
+        self,
+    ):
+        # GIVEN: Kata example input
+        parser = InputParser()
+
+        # WHEN: InputParser.parse() is called
+        _, missions = parser.parse(KATA_INPUT)
+
+        # THEN: Returns two (Rover, command_string) pairs with correct values
+        self.assertEqual(len(missions), 2)
+        rover1, cmd1 = missions[0]
+        self.assertEqual(rover1.x, 1)
+        self.assertEqual(rover1.y, 2)
+        self.assertEqual(rover1.heading, Heading.N)
+        self.assertEqual(cmd1, "LMLMLMLMM")
+        rover2, cmd2 = missions[1]
+        self.assertEqual(rover2.x, 3)
+        self.assertEqual(rover2.y, 3)
+        self.assertEqual(rover2.heading, Heading.E)
+        self.assertEqual(cmd2, "MMRMMRMRRM")

--- a/tests/adapters/test_input_parser.py
+++ b/tests/adapters/test_input_parser.py
@@ -63,3 +63,13 @@ class TestInputParser(unittest.TestCase):
         # WHEN / THEN: ValueError raised with "Plateau" in message
         with self.assertRaisesRegex(ValueError, "Plateau"):
             parser.parse("5\n1 2 N\nM\n")
+
+    def test_cli_be_001_s2_given_invalid_heading_when_parse_then_raises_value_error(
+        self,
+    ):
+        # GIVEN: Rover line has invalid heading "X"
+        parser = InputParser()
+
+        # WHEN / THEN: ValueError raised with "heading" in message
+        with self.assertRaisesRegex(ValueError, "heading"):
+            parser.parse("5 5\n1 2 X\nM\n")

--- a/tests/adapters/test_input_parser.py
+++ b/tests/adapters/test_input_parser.py
@@ -41,3 +41,15 @@ class TestInputParser(unittest.TestCase):
         self.assertEqual(rover2.y, 3)
         self.assertEqual(rover2.heading, Heading.E)
         self.assertEqual(cmd2, "MMRMMRMRRM")
+
+    def test_cli_story_001_s4_given_single_rover_input_when_parse_then_one_mission(
+        self,
+    ):
+        # GIVEN: Input with plateau and one rover block
+        parser = InputParser()
+
+        # WHEN: InputParser.parse() is called
+        _, missions = parser.parse("5 5\n3 3 E\nMMRMMRMRRM\n")
+
+        # THEN: Returns one (Rover, command_string) pair
+        self.assertEqual(len(missions), 1)

--- a/tests/adapters/test_input_parser.py
+++ b/tests/adapters/test_input_parser.py
@@ -53,3 +53,13 @@ class TestInputParser(unittest.TestCase):
 
         # THEN: Returns one (Rover, command_string) pair
         self.assertEqual(len(missions), 1)
+
+    def test_cli_be_001_s1_given_bad_plateau_when_parse_then_raises_value_error(
+        self,
+    ):
+        # GIVEN: Plateau line is missing height
+        parser = InputParser()
+
+        # WHEN / THEN: ValueError raised with "Plateau" in message
+        with self.assertRaisesRegex(ValueError, "Plateau"):
+            parser.parse("5\n1 2 N\nM\n")


### PR DESCRIPTION
## 📋 Description
Implements an InputParser adapter that converts raw stdin text into domain objects, and a __main__.py entry point so operators can run a full mission via `python -m mars_rover < input.txt`.

## 🔗 Related Issue
Closes #29

## 🧪 How to Test
1. Create a test input file:
   ```
   5 5
   1 2 N
   LMLMLMLMM
   3 3 E
   MMRMMRMRM
   ```
2. Run: `python -m mars_rover < input.txt`
3. Verify output shows final rover positions
4. Run unit tests: `pytest tests/adapters/test_input_parser.py`
5. Run linters: `ruff check . && black --check . && isort --check .`

## ✅ Checklist
- [x] Follows commit message convention
- [x] Pre-commit hooks pass
- [x] Linked to a GitHub issue
- [x] PR title matches branch type